### PR TITLE
Removing night time presentations for blinky dancer

### DIFF
--- a/schedules/_seniors_daily.js
+++ b/schedules/_seniors_daily.js
@@ -16,7 +16,7 @@ events.push({
   who: c.seniors,
   message: '<!channel> Hurry! Kick-off in 1 minute. https://zoom.us/j/525181230'
 });
-
+/* Removing for blinky dancer presentations
 events.push({
   when: d.daily625pm,
   who: c.seniors,
@@ -28,5 +28,5 @@ events.push({
   who: c.seniors,
   message: '<!channel> Student Presentations in 1 minute. https://zoom.us/j/525181230'
 });
-
+*/
 module.exports = events;


### PR DESCRIPTION
We will have different configuration for tonight's presentation. Will change back to include notifications after.
